### PR TITLE
Release v1.3.3: Add Joomla 6 support and update metadata

### DIFF
--- a/src/mod_ttstand.xml
+++ b/src/mod_ttstand.xml
@@ -6,11 +6,12 @@
   <license>GNU/GPL</license>
   <authorEmail>info@gileba.be</authorEmail>
   <authorUrl>www.gileba.be</authorUrl>
-  <version>1.3.2</version>
-  <creationDate>2023-12-08</creationDate>
+  <version>1.3.3</version>
+  <creationDate>2026-03-13</creationDate>
   <description>
     This module shows tabletennis information from API-powered suppliers on your Joomla site.
   </description>
+  <targetplatform name="joomla" version="(4|5|6)" />
   <changelogurl>http://updates.gileba.be/changelogs/mod_ttstand.xml</changelogurl>
   <updateservers>
    <server type="extension" priority="1" name="TT Stand">

--- a/update-server/mod_ttstand.xml
+++ b/update-server/mod_ttstand.xml
@@ -4,7 +4,7 @@
 		<description>A module to use the widgets from TTapp</description>
 		<element>mod_ttstand</element>
 		<type>module</type>
-		<version>1.3.2</version>
+		<version>1.3.3</version>
 		<client>site</client>
 		<infourl title="TT Stand"></infourl>
 		<changelogurl>https://gileba.be/changelogs/mod_ttstand.xml</changelogurl>
@@ -15,6 +15,6 @@
 		<tags>
 			<tag>stable</tag>
 		</tags>
-		<targetplatform name="joomla" version="(4|5)" />
+		<targetplatform name="joomla" version="(4|5|6)" />
 	</update>
 </updates>


### PR DESCRIPTION
## Summary
This release updates the TT Stand module to support Joomla 6 while maintaining compatibility with Joomla 4 and 5.

## Key Changes
- **Version bump**: Updated from 1.3.2 to 1.3.3
- **Joomla 6 support**: Extended target platform compatibility from `(4|5)` to `(4|5|6)` in both manifest files
- **Metadata updates**: Updated creation date to reflect the release date (2026-03-13)

## Files Modified
- `src/mod_ttstand.xml`: Main module manifest
- `update-server/mod_ttstand.xml`: Update server configuration

The changes ensure the module is compatible with the latest Joomla versions while maintaining backward compatibility with Joomla 4 and 5.

https://claude.ai/code/session_01SQ1Y8S82VpkGBC1XFzhw4B